### PR TITLE
First suggestion for ad hoc role execution for hosts and hostgroups. …

### DIFF
--- a/app/assets/javascripts/foreman_ansible/show_ad_hoc_role_modal.js
+++ b/app/assets/javascripts/foreman_ansible/show_ad_hoc_role_modal.js
@@ -1,0 +1,11 @@
+function show_ad_hoc_role_modal(modal_id = null) {
+  var modal_window = modal_id == null ? $('#adHocRoleModal') : $('#adHocRoleModal' + modal_id);
+  modal_window.modal({'show': true});
+  modal_window.find('a[rel="popover-modal"]').popover();
+  activate_select2(modal_window);
+}
+
+function close_ad_hoc_role_modal(modal_id = null) {
+  var modal_window = modal_id == null ? $('#adHocRoleModal') : $('#adHocRoleModal' + modal_id);
+  modal_window.modal('hide');
+}

--- a/app/controllers/api/v2/ansible_roles_controller.rb
+++ b/app/controllers/api/v2/ansible_roles_controller.rb
@@ -37,6 +37,36 @@ module Api
         @obsoleted = @importer.obsolete!
       end
 
+      api :POST, '/ansible/hosts/:host_id/ansible_roles/:id/play_ad_hoc_role_on_host', N_('Plays an Ansible role on a host ad hoc')
+      param :id, :identifier, :required => true
+      param :host_id, :identifier, :required => true
+      def play_ad_hoc_role_on_host
+        # FIXME: find_resource does not work here for some reason -> RecordNotFound
+        @ansible_role = AnsibleRole.find(params[:id])
+        @host = Host.find(params[:host_id])
+        @result = {
+          :host => @host, :foreman_tasks => async_task(
+            ::Actions::ForemanAnsible::PlayHostRole, @host, @ansible_role
+          )
+        }
+        render_message @result
+      end
+
+      api :POST, '/ansible/hostgroups/:hostgroup_id/ansible_roles/:id/play_ad_hoc_role', N_('Plays an Ansible role on a host group ad hoc')
+      param :id, :identifier, :required => true
+      param :hostgroup_id, :identifier, :required => true
+      def play_ad_hoc_role_on_hostgroup
+        # FIXME: find_resource does not work here for some reason -> RecordNotFound
+        @ansible_role = AnsibleRole.find(params[:id])
+        @hostgroup = Hostgroup.find(params[:hostgroup_id])
+        @result = {
+          :hostgroup => @hostgroup, :foreman_tasks => async_task(
+            ::Actions::ForemanAnsible::PlayHostgroupRole, @hostgroup, @ansible_role
+          )
+        }
+        render_message @result
+      end
+
       private
 
       def find_proxy
@@ -46,6 +76,15 @@ module Api
 
       def create_importer
         @importer = ForemanAnsible::ApiRolesImporter.new(@proxy)
+      end
+
+      def action_permission
+        case params[:action]
+        when 'play_ad_hoc_role'
+          :view
+        else
+          super
+        end
       end
     end
   end

--- a/app/controllers/foreman_ansible/api/v2/hostgroups_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/hostgroups_controller_extensions.rb
@@ -40,11 +40,37 @@ module ForemanAnsible
 
             render_message @result
           end
+
+          api :POST, '/hostgroups/:id/play_ad_hoc_role', N_('Plays an Ansible role ad hoc')
+          param :id, :identifier, :required => true
+          param :the_role_id, String, :required => true
+
+          def play_ad_hoc_role
+            # FIXME: When using just role_id, find resource will throw an
+            # exception: "undefined method `name' for nil:NilClass"
+            find_resource
+            find_ansible_role(params.require(:the_role_id))
+
+            @result = {
+              :hostgroup => @hostgroup, :role => @ansible_role,
+              :foreman_tasks => async_task(
+                ::Actions::ForemanAnsible::PlayHostgroupRole,
+                @hostgroup, @ansible_role
+              )
+            }
+
+            render_message @result
+          end
         end
 
         private
 
-        # TODO: A better implementation of find_multiple should be available in hostgroups_controller
+        def find_ansible_role(id)
+          @ansible_role = AnsibleRole.find(id)
+        end
+
+        # TODO: A better implementation of find_multiple should be available in
+        # hostgroups_controller
 
         def find_multiple
           hostgroup_ids = params.fetch(:hostgroup_ids, [])

--- a/app/controllers/foreman_ansible/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/hosts_controller_extensions.rb
@@ -24,7 +24,8 @@ module ForemanAnsible
           param :id, Array, :required => true
 
           def multiple_play_roles
-            # TODO: How to prevent that find_resource is triggered by hosts_controller?
+            # TODO: How to prevent that find_resource is triggered by
+            # hosts_controller?
             @result = []
 
             @host.each do |item|
@@ -37,9 +38,31 @@ module ForemanAnsible
 
             render_message @result
           end
+
+          api :POST, '/hosts/:id/play_ad_hoc_role', N_('Plays an Ansible role ad hoc')
+          param :id, String, :required => true
+          param :the_role_id, String, :required => true
+
+          def play_ad_hoc_role
+            # FIXME: When using just role_id, find resource will throw an
+            # exception: "undefined method `name' for nil:NilClass"
+            find_ansible_role(params.require(:the_role_id))
+            @result = {
+              :host => @host, :role => @ansible_role,
+              :foreman_tasks => async_task(
+                ::Actions::ForemanAnsible::PlayHostRole, @host, @ansible_role
+              )
+            }
+
+            render_message @result
+          end
         end
 
         private
+
+        def find_ansible_role(id)
+          @ansible_role = AnsibleRole.find(id)
+        end
 
         def action_permission
           case params[:action]

--- a/app/controllers/foreman_ansible/concerns/hostgroups_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/concerns/hostgroups_controller_extensions.rb
@@ -7,7 +7,24 @@ module ForemanAnsible
 
       def play_roles
         find_resource
-        task = async_task(::Actions::ForemanAnsible::PlayHostgroupRoles, @hostgroup)
+        task = async_task(
+          ::Actions::ForemanAnsible::PlayHostgroupRoles,
+          @hostgroup
+        )
+        redirect_to task
+      rescue Foreman::Exception => e
+        error e.message
+        redirect_to hostgroups_path
+      end
+
+
+      def play_ad_hoc_role
+        find_resource
+        @ansible_role = AnsibleRole.find(params[:ansible_role][:id])
+        task = async_task(
+          ::Actions::ForemanAnsible::PlayHostgroupRole,
+          @hostgroup, @ansible_role
+        )
         redirect_to task
       rescue Foreman::Exception => e
         error e.message

--- a/app/controllers/foreman_ansible/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/concerns/hosts_controller_extensions.rb
@@ -23,6 +23,20 @@ module ForemanAnsible
         redirect_to hosts_path
       end
 
+
+      def play_ad_hoc_role
+        find_resource
+        @ansible_role = AnsibleRole.find(params[:ansible_role][:id])
+        task = async_task(
+          ::Actions::ForemanAnsible::PlayHostRole,
+          @host, @ansible_role
+        )
+        redirect_to task
+      rescue Foreman::Exception => e
+        error e.message
+        redirect_to host_path(@host)
+      end
+
       private
 
       def action_permission

--- a/app/helpers/foreman_ansible/hosts_helper_extensions.rb
+++ b/app/helpers/foreman_ansible/hosts_helper_extensions.rb
@@ -9,6 +9,7 @@ module ForemanAnsible
     end
 
     def host_title_actions_with_run_ansible_roles(*args)
+
       if args.first.ansible_roles.present? ||
          args.first.inherited_ansible_roles.present?
         button = link_to(
@@ -19,7 +20,16 @@ module ForemanAnsible
           :'data-no-turbolink' => true
         )
         title_actions(button_group(button))
+
+      buttons = []
+      buttons.append(create_ad_hoc_role_button)
+      if args.first.ansible_roles.present? ||
+         args.first.inherited_ansible_roles.present?
+        buttons.append(create_play_role_button(args.first.id))
       end
+
+      title_actions(button_group(buttons))
+
       host_title_actions_without_run_ansible_roles(*args)
     end
 
@@ -28,6 +38,27 @@ module ForemanAnsible
         [[_('Play Ansible roles'),
           multiple_play_roles_hosts_path,
           false]]
+    end
+
+    private
+
+    def create_ad_hoc_role_button
+      link_to_function(
+        icon_text('play', ' ' + _('Ad hoc Ansible role'), :kind => 'fa'),
+        'show_ad_hoc_role_modal()',
+        :id => :ansible_ad_hoc_role_button,
+        :class => 'btn btn-default'
+      )
+    end
+
+    def create_play_role_button(id)
+      link_to(
+        icon_text('play', ' ' + _('Ansible roles'), :kind => 'fa'),
+        play_roles_host_path(:id => id),
+        :id => :ansible_roles_button,
+        :class => 'btn btn-default',
+        :'data-no-turbolink' => true
+      )
     end
   end
 end

--- a/app/lib/actions/foreman_ansible/play_host_role.rb
+++ b/app/lib/actions/foreman_ansible/play_host_role.rb
@@ -1,14 +1,13 @@
 module Actions
   module ForemanAnsible
-    # Action that initiates the playbook run for roles assigned to
-    # the host. It does that either locally or via a proxy when available.
-    class PlayHostRoles < PlayRoles
-      def plan(host, proxy_selector = ::ForemanAnsible::ProxySelector.new)
+    # Actions that initiaztes the playbook run for roles assigned to
+    # the host. It doest that either locally or via a proxy when available.
+    class PlayHostRole < PlayRoles
+      def plan(host, ansible_role, proxy_selector = ::ForemanAnsible::ProxySelector.new)
         input[:host] = { :id => host.id, :name => host.fqdn }
         proxy = proxy_selector.determine_proxy(host)
         inventory_creator = ::ForemanAnsible::InventoryCreator.new([host])
-        role_names = host.all_ansible_roles.map(&:name)
-        playbook_creator = ::ForemanAnsible::PlaybookCreator.new(role_names)
+        playbook_creator = ::ForemanAnsible::PlaybookCreator.new([ansible_role.name])
         plan_delegated_action(proxy, ::ForemanAnsibleCore::Actions::RunPlaybook,
                               :inventory => inventory_creator.to_hash.to_json,
                               :playbook => playbook_creator.roles_playbook)
@@ -20,7 +19,7 @@ module Actions
       end
 
       def humanized_name
-        _('Play Ansible roles')
+        _('Play ad hoc Ansible role')
       end
     end
   end

--- a/app/lib/actions/foreman_ansible/play_hostgroup_role.rb
+++ b/app/lib/actions/foreman_ansible/play_hostgroup_role.rb
@@ -1,0 +1,31 @@
+module Actions
+  module ForemanAnsible
+
+    # Action that initiates the playbook run for an Ansible role of a
+    # hostgroup. It does that either locally or via a proxy when available.
+    class PlayHostgroupRole < PlayRoles
+      def plan(hostgroup, ansible_role, proxy_selector = ::ForemanAnsible::ProxySelector.new)
+        if hostgroup.hosts.empty?
+          raise ::Foreman::Exception.new(N_('host group is empty'))
+        end
+        input[:hostgroup] = { :id => hostgroup.id, :name => hostgroup.name }
+        proxy = proxy_selector.determine_proxy(hostgroup.hosts[0])
+        inventory_creator = ::ForemanAnsible::InventoryCreator.new(hostgroup.hosts)
+        playbook_creator = ::ForemanAnsible::PlaybookCreator.new([ansible_role.name])
+        plan_delegated_action(proxy, ::ForemanAnsibleCore::Actions::RunPlaybook,
+                              :inventory => inventory_creator.to_hash.to_json,
+                              :playbook => playbook_creator.roles_playbook)
+        plan_self
+      end
+
+      def humanized_input
+        _('on host group %{name}') %
+          { :name => input.fetch(:hostgroup, {})[:name] }
+      end
+
+      def humanized_name
+        _('Play ad hoc Ansible role')
+      end
+    end
+  end
+end

--- a/app/lib/actions/foreman_ansible/play_roles.rb
+++ b/app/lib/actions/foreman_ansible/play_roles.rb
@@ -1,0 +1,34 @@
+module Actions
+  module ForemanAnsible
+    # The base class for similar actions that execute Ansible roles.
+    class PlayRoles < Actions::EntryAction
+      include ::Actions::Helpers::WithContinuousOutput
+      include ::Actions::Helpers::WithDelegatedAction
+
+      def finalize
+        return unless delegated_output[:exit_status].to_s != '0'
+        error! _('Playbook execution failed')
+      end
+
+      def rescue_strategy
+        ::Dynflow::Action::Rescue::Fail
+      end
+
+      def humanized_output
+        continuous_output.humanize
+      end
+
+      def continuous_output_providers
+        super << self
+      end
+
+      def fill_continuous_output(continuous_output)
+        delegated_output.fetch('result', []).each do |raw_output|
+          continuous_output.add_raw_output(raw_output)
+        end
+      rescue => e
+        continuous_output.add_exception(_('Error loading data from proxy'), e)
+      end
+    end
+  end
+end

--- a/app/overrides/hostgroup_role_execution.rb
+++ b/app/overrides/hostgroup_role_execution.rb
@@ -1,0 +1,15 @@
+# Displays Ansible roles execution buttons in host group action buttons
+Deface::Override.new(
+  :virtual_path => 'hostgroups/index',
+  :name => 'hostgroup_ansible_role_execution',
+  :replace => "erb[loud]:contains('action_buttons')",
+  :partial => 'foreman_ansible/ansible_roles/hostgroup_ansible_role_execution'
+)
+
+Deface::Override.new(
+  :virtual_path => 'hostgroups/index',
+  :name => 'hostgroup_ansible_role_execution_forms',
+  :insert_after => "table",
+  :partial =>
+    'foreman_ansible/ansible_roles/hostgroup_ansible_role_execution_forms'
+)

--- a/app/views/foreman_ansible/ansible_roles/_host_ad_hoc_role_modal.html.erb
+++ b/app/views/foreman_ansible/ansible_roles/_host_ad_hoc_role_modal.html.erb
@@ -1,0 +1,24 @@
+<!-- ad hoc role modal window -->
+<% javascript 'foreman_ansible/show_ad_hoc_role_modal' %>
+<div class="modal fade" id="adHocRoleModal" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" onclick="close_ad_hoc_role_modal(); return false;"><span aria-hidden="true">&times;</span><span class="sr-only"><%= _('Close') %></span></button>
+        <h4 class="modal-title"><%= _('Ad Hoc Ansible Role Execution') %></h4>
+      </div>
+      <div class="modal-body">
+        <%= form_for :ansible_role, :url => play_ad_hoc_role_host_path() do |f| -%>
+        <p><%= _('Select the role you want to execute on host %s via Ansible.') % @host.name %></p>
+        <%= all_ansible_roles = AnsibleRole.find_each rescue []
+            selectable_f f, :id, options_for_select(all_ansible_roles.collect { | role | [role.name, role.id] }), {},
+            {:label => _("Ansible role"), :disabled => all_ansible_roles.map { |e| e.name }.empty?, :style => "width:400px"} %>
+      </div>
+      <div class="modal-footer">
+        <%= submit_tag _("Play role"), :class => "btn btn-primary" %>
+        <% end -%>
+        <button type="button" class="btn btn btn-default" onclick="close_ad_hoc_role_modal(); return false;"><%= _('Cancel') %></button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/foreman_ansible/ansible_roles/_hostgroup_ansible_role_execution.erb
+++ b/app/views/foreman_ansible/ansible_roles/_hostgroup_ansible_role_execution.erb
@@ -1,0 +1,11 @@
+<%=
+args = []
+args.append(display_link_if_authorized(_('Nest'),    hash_for_nest_hostgroup_path(:id => hostgroup)))
+args.append(display_link_if_authorized(_('Clone'),   hash_for_clone_hostgroup_path(:id => hostgroup)))
+if !hostgroup.all_ansible_roles.empty?
+  args.append(display_link_if_authorized(_('Play Roles'),   hash_for_play_roles_hostgroup_path(:id => hostgroup),   :'data-no-turbolink' => true))
+end
+args.append(link_to_function_if_authorized(_('Ad hoc Ansible role'),   "show_ad_hoc_role_modal(%s)" % hostgroup.id))
+args.append(display_delete_if_authorized(hash_for_hostgroup_path(:id => hostgroup).merge(:auth_object => hostgroup, :authorizer => authorizer), :data => { :confirm => warning_message(hostgroup) }))
+action_buttons(args)
+%>

--- a/app/views/foreman_ansible/ansible_roles/_hostgroup_ansible_role_execution_forms.erb
+++ b/app/views/foreman_ansible/ansible_roles/_hostgroup_ansible_role_execution_forms.erb
@@ -1,0 +1,25 @@
+<% javascript 'foreman_ansible/show_ad_hoc_role_modal' %>
+<% @hostgroups.each do |hostgroup| %>
+<div class="modal fade" id='adHocRoleModal<%= hostgroup.id %>' role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" onclick="close_ad_hoc_role_modal(<%= hostgroup.id %>); return false;"><span aria-hidden="true">&times;</span><span class="sr-only"><%= _('Close') %></span></button>
+        <h4 class="modal-title"><%= _('Ad Hoc Ansible Role Execution') %></h4>
+      </div>
+      <div class="modal-body">
+        <%= form_for :ansible_role, :url => hash_for_play_ad_hoc_role_hostgroup_path(:id => hostgroup) do |f| -%>
+        <p><%= _('Select the role you want to execute on hostgroup %s via Ansible.') % hostgroup.name %></p>
+        <%= all_ansible_roles = AnsibleRole.find_each rescue []
+            selectable_f f, :id, options_for_select(all_ansible_roles.collect { | role | [role.name, role.id] }), {},
+            {:label => _("Ansible role"), :disabled => all_ansible_roles.map { |e| e.name }.empty?, :style => "width:400px"} %>
+      </div>
+      <div class="modal-footer">
+        <%= submit_tag _("Play role"), :class => "btn btn-primary" %>
+        <% end -%>
+        <button type="button" class="btn btn btn-default" onclick="close_ad_hoc_role_modal(<%= hostgroup.id %>); return false;"><%= _('Cancel') %></button>
+      </div>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,17 @@ Rails.application.routes.draw do
             end
             collection do
               post :multiple_play_roles
+            resources :ansible_roles, :only => [] do
+              member do
+                post :play_ad_hoc_role_on_host
+              end
+            end
+          end
+          resources :hostgroups, :only => [] do
+            resources :ansible_roles, :only => [] do
+              member do
+                post :play_ad_hoc_role_on_hostgroup
+              end
             end
           end
         end

--- a/test/functional/api/v2/hostgroups_controller_test.rb
+++ b/test/functional/api/v2/hostgroups_controller_test.rb
@@ -8,6 +8,7 @@ module Api
       setup do
         @host1 = FactoryGirl.create(:host, :with_hostgroup)
         @host2 = FactoryGirl.create(:host, :with_hostgroup)
+        @role = FactoryGirl.create(:ansible_role)
       end
 
       after do
@@ -42,6 +43,21 @@ module Api
         response = JSON.parse(@response.body)
 
         assert response['message'].length == 2, 'should trigger two tasks'
+        assert_response :success
+      end
+
+      test 'should trigger an ad hoc role' do
+        post :play_ad_hoc_role,
+             :id => @host1.hostgroup.id, :the_role_id => @role.id
+        response = JSON.parse(@response.body)
+
+        assert response['message']['foreman_tasks'].key?('id'),
+               'task id not contained in response'
+        assert response['message']['role'].key?('id'),
+               'role id not contained in response'
+        assert_equal response['message']['hostgroup']['name'],
+                     @host1.hostgroup.name,
+                     'host group name not contained in response'
         assert_response :success
       end
     end

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -8,6 +8,7 @@ module Api
       setup do
         @host1 = FactoryGirl.create(:host)
         @host2 = FactoryGirl.create(:host)
+        @role = FactoryGirl.create(:ansible_role)
       end
 
       after do
@@ -41,6 +42,21 @@ module Api
         response = JSON.parse(@response.body)
 
         assert response['message'].length == 2, 'should trigger two tasks'
+        assert_response :success
+      end
+
+      test 'should trigger an ad hoc role' do
+        post :play_ad_hoc_role,
+             :id => @host1.id, :the_role_id => @role.id
+        response = JSON.parse(@response.body)
+
+        assert response['message']['foreman_tasks'].key?('id'),
+               'task id not contained in response'
+        assert response['message']['role'].key?('id'),
+               'role id not contained in response'
+        assert_equal response['message']['hostgroup']['name'],
+                     @host1.name,
+                     'host name not contained in response'
         assert_response :success
       end
     end


### PR DESCRIPTION
…Only API v2, no UI support yet. Additionally, find_resource cannot be used for some reason when using nested routes as it is done in this implementation (RecordNotFound). Factoring out common methods in the EntryActions is recommended, maybe play_host_role and play_host_roles can be unified one day. The solution for the proxy delegation is still pending and depends on the outcomes of pull request of the hostgroup branch and its follow-ups.