### PR TITLE
Add any_errors_fatal setting

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -76,6 +76,12 @@ class Setting
                  ' it is ready after a reboot.'),
               '360',
               N_('Post-provision timeout')
+            ),
+            set(
+              'ansible_any_errors_fatal',
+              N_('Aborts a play immediately when one host of the play fails.'),
+              true,
+              N_('Any errors fatal')
             )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))

--- a/app/services/foreman_ansible/playbook_creator.rb
+++ b/app/services/foreman_ansible/playbook_creator.rb
@@ -8,7 +8,11 @@ module ForemanAnsible
     end
 
     def roles_playbook
-      playbook = ['hosts' => 'all', 'roles' => role_names]
+      playbook = [
+        'hosts' => 'all',
+        'any_errors_fatal' => Setting[:ansible_any_errors_fatal],
+        'roles' => role_names
+      ]
       playbook.to_yaml
     end
 


### PR DESCRIPTION
I don't like for our deployments when Ansible fails but continues with hosts that are left. 

It would be better to abort the play immediately in order to have the error right at the bottom of the console output, which can be achieved with this:

http://docs.ansible.com/ansible/playbooks_error_handling.html#aborting-the-play